### PR TITLE
Fix crash when building release version of android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+android/fastlane/README.md

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,7 +133,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.0"
+        versionName "1.0.1"
         multiDexEnabled true
     }
     splits {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,3 +36,14 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
+
+subprojects {
+    afterEvaluate {project ->
+        if (project.hasProperty("android")) {
+            android {
+                compileSdkVersion 28
+                buildToolsVersion "28.0.3"
+            }
+        }
+    }
+}

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -8,7 +8,7 @@ platform :android do
     gradle(task: "clean assembleRelease")
     firebase_app_distribution(
         app: "1:3198314753:android:8b1c71a1dbb33a7e201300",
-        release_notes: "Please uninstall all previous version before installing this one",
+        release_notes: "Bug fix",
         testers: testers,
         firebase_cli_path: "/usr/local/bin/firebase"
     )


### PR DESCRIPTION
Part of error message

```
Execution failed for task ':react-native-ble-peripheral:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed
     /Users/ideataha/.gradle/caches/transforms-2/files-2.1/7fb1d9507999f02f44dc8cadb1d3320b/appcompat-1.0.2/res/values-v26/values-v26.xml:5:5-8:13: AAPT: error: resource android:attr/colorError not found.
         
     /Users/ideataha/.gradle/caches/transforms-2/files-2.1/7fb1d9507999f02f44dc8cadb1d3320b/appcompat-1.0.2/res/values-v26/values-v26.xml:9:5-12:13: AAPT: error: resource android:attr/colorError not found.
```